### PR TITLE
Expand world system with tests

### DIFF
--- a/src/core/game.test.ts
+++ b/src/core/game.test.ts
@@ -22,4 +22,35 @@ describe('Game', () => {
     expect(game.state.balance).not.toBe(initialState.balance);
     expect(game.state.population).not.toBe(initialState.population);
   });
+
+  it('reduces industrial tax income when energy is insufficient', () => {
+    const world = new World();
+    world.placeBuilding(0, 0, {
+      id: 'r',
+      type: 'Residential',
+      buildCost: 0,
+      upkeepPerDay: 0,
+      capacity: 20,
+      energyUseKW: 1000
+    });
+    world.placeBuilding(1, 0, {
+      id: 'i',
+      type: 'Industrial',
+      buildCost: 0,
+      upkeepPerDay: 0,
+      jobs: 10,
+      productivity: 1,
+      energyUseKW: 1000
+    });
+    world.placeBuilding(2, 0, {
+      id: 'p',
+      type: 'PowerPlant',
+      buildCost: 0,
+      upkeepPerDay: 0,
+      capacityMW: 1
+    });
+    const game = new Game({ ...initialState, balance: 0, population: 10 }, world);
+    game.tick();
+    expect(game.state.balance).toBe(15);
+  });
 });

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -23,7 +23,8 @@ export class Game {
 
     const jobs = this.world.totalJobs();
     const employed = Math.min(this.state.population, jobs);
-    const taxIncome = this.economy.calculateTaxIncome(this.state.population, employed, this.state.taxes);
+    const effectiveJobs = employed * coverage;
+    const taxIncome = this.economy.calculateTaxIncome(this.state.population, effectiveJobs, this.state.taxes);
     const upkeep = this.economy.calculateUpkeep(this.world.allBuildings());
     const loanPayment = this.state.loans ? this.state.loans.paymentPerDay : 0;
     const newBalance = this.economy.applyDay(this.state.balance, taxIncome, upkeep, loanPayment);

--- a/src/core/world.test.ts
+++ b/src/core/world.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { World } from './world';
+import { Residential, Industrial, PowerPlant } from './types';
+
+describe('World', () => {
+  it('places buildings and aggregates stats', () => {
+    const world = new World();
+    const r: Residential = {
+      id: 'r1',
+      type: 'Residential',
+      buildCost: 0,
+      upkeepPerDay: 0,
+      energyUseKW: 5,
+      capacity: 10
+    };
+    const i: Industrial = {
+      id: 'i1',
+      type: 'Industrial',
+      buildCost: 0,
+      upkeepPerDay: 0,
+      energyUseKW: 8,
+      jobs: 7,
+      productivity: 1
+    };
+    const p: PowerPlant = {
+      id: 'p1',
+      type: 'PowerPlant',
+      buildCost: 0,
+      upkeepPerDay: 0,
+      capacityMW: 1
+    };
+
+    world.placeBuilding(0, 0, r);
+    world.placeBuilding(1, 0, i);
+    world.placeBuilding(2, 0, p);
+
+    expect(world.getBuilding(0, 0)).toBe(r);
+    expect(world.residentialCapacity()).toBe(10);
+    expect(world.totalJobs()).toBe(7);
+    expect(world.energyConsumers()).toEqual([{ energyUseKW: 5 }, { energyUseKW: 8 }]);
+    expect(world.powerPlants()).toEqual([p]);
+  });
+});

--- a/src/core/world.ts
+++ b/src/core/world.ts
@@ -1,4 +1,10 @@
-import { Building, EnergyConsumer, PowerPlant } from './types';
+import {
+  Building,
+  EnergyConsumer,
+  PowerPlant,
+  Residential,
+  Industrial
+} from './types';
 
 export class World {
   width: number;
@@ -18,19 +24,23 @@ export class World {
     this.buildings.set(this.coord(x, y), building);
   }
 
+  getBuilding(x: number, y: number): Building | undefined {
+    return this.buildings.get(this.coord(x, y));
+  }
+
   allBuildings(): Building[] {
     return Array.from(this.buildings.values());
   }
 
   residentialCapacity(): number {
     return this.allBuildings()
-      .filter((b): b is any => b.type === 'Residential')
+      .filter((b): b is Residential => b.type === 'Residential')
       .reduce((sum, b) => sum + b.capacity, 0);
   }
 
   totalJobs(): number {
     return this.allBuildings()
-      .filter((b): b is any => b.type === 'Industrial')
+      .filter((b): b is Industrial => b.type === 'Industrial')
       .reduce((sum, b) => sum + b.jobs, 0);
   }
 


### PR DESCRIPTION
## Summary
- add building lookup in world and tighten type guards
- cover world building management with unit tests
- scale industrial tax income by energy coverage and test it

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68962c7f2d988328a84b4ce6679c6c7e