### PR TITLE
Enable road placement via grid clicks

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -1,0 +1,22 @@
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { App } from './App';
+import { useCityStore } from '../state/store';
+import { World } from '../core/world';
+
+describe('App', () => {
+  beforeEach(() => {
+    useCityStore.setState((s) => ({ ...s, world: new World() }));
+  });
+
+  it('places a road when a cell is clicked', () => {
+    const { getByTestId } = render(<App />);
+    const cell = getByTestId('cell-0-0');
+    fireEvent.click(cell);
+    const world = useCityStore.getState().world;
+    expect(world.getBuilding(0, 0)?.type).toBe('Road');
+    const updatedCell = getByTestId('cell-0-0');
+    expect(updatedCell.getAttribute('fill')).toBe('#666');
+  });
+});

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,7 +5,7 @@ const GRID_SIZE = 20;
 const CELL_SIZE = 20;
 
 export const App: React.FC = () => {
-  const { state } = useCityStore();
+  const { state, world, placeRoad } = useCityStore();
   const lines: JSX.Element[] = [];
   for (let i = 0; i <= GRID_SIZE; i++) {
     lines.push(
@@ -15,6 +15,26 @@ export const App: React.FC = () => {
       <line key={`v${i}`} x1={i * CELL_SIZE} y1={0} x2={i * CELL_SIZE} y2={GRID_SIZE * CELL_SIZE} />
     );
   }
+  const cells: JSX.Element[] = [];
+  for (let y = 0; y < GRID_SIZE; y++) {
+    for (let x = 0; x < GRID_SIZE; x++) {
+      const building = world.getBuilding(x, y);
+      const fill = building?.type === 'Road' ? '#666' : 'transparent';
+      cells.push(
+        <rect
+          key={`${x}-${y}`}
+          data-testid={`cell-${x}-${y}`}
+          x={x * CELL_SIZE}
+          y={y * CELL_SIZE}
+          width={CELL_SIZE}
+          height={CELL_SIZE}
+          fill={fill}
+          stroke="none"
+          onClick={() => placeRoad(x, y)}
+        />
+      );
+    }
+  }
   return (
     <div className="app">
       <h1>Sim City MVP</h1>
@@ -22,6 +42,7 @@ export const App: React.FC = () => {
       <div>Balance: {state.balance}</div>
       <div>Population: {state.population}</div>
       <svg width={GRID_SIZE * CELL_SIZE} height={GRID_SIZE * CELL_SIZE} className="grid">
+        {cells}
         {lines}
       </svg>
     </div>

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,9 +1,12 @@
 import create from 'zustand';
-import { CityState } from '../core/types';
+import { CityState, BuildingBase } from '../core/types';
+import { World } from '../core/world';
 
 interface CityStore {
   state: CityState;
+  world: World;
   setState: (partial: Partial<CityState>) => void;
+  placeRoad: (x: number, y: number) => void;
 }
 
 export const useCityStore = create<CityStore>((set) => ({
@@ -15,5 +18,17 @@ export const useCityStore = create<CityStore>((set) => ({
     taxes: { citizen: 1, industry: 1 },
     loans: null
   },
-  setState: (partial) => set((s) => ({ state: { ...s.state, ...partial } }))
+  world: new World(),
+  setState: (partial) => set((s) => ({ state: { ...s.state, ...partial } })),
+  placeRoad: (x, y) =>
+    set((s) => {
+      const road: BuildingBase = {
+        id: `road-${x}-${y}`,
+        type: 'Road',
+        buildCost: 0,
+        upkeepPerDay: 0
+      };
+      s.world.placeBuilding(x, y, road);
+      return { world: s.world };
+    })
 }));

--- a/task.md
+++ b/task.md
@@ -155,8 +155,8 @@ interface PowerPlant extends BuildingBase {
 - [x] Vite + TS + React, базовая структура, ESLint/Prettier.
 - [x] Состояние игры (`Game`, `World`, `CityState`), ивенты.
 - [x] Рендер сетки 20×20.
-- [ ] Выбор клетки, размещение `Road`.
-- [ ] Панель инструментов (выбор типа постройки), undo/redo (простой стек).
+ - [x] Выбор клетки, размещение `Road`.
+ - [ ] Панель инструментов (выбор типа постройки), undo/redo (простой стек).
 
 ### Этап B — Здания и экономика (2–3 дня)
 - [x] Типы зданий: `Residential`, `Industrial`, `PowerPlant`.


### PR DESCRIPTION
## Summary
- Allow clicking grid cells to place road tiles
- Maintain world state and expose `placeRoad` in store
- Add test covering road placement and update task list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68963c92fe088328a2bbd3f02dda2bd4