### PR TITLE
Add building toolbar and undo/redo

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -1,13 +1,23 @@
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
 import React from 'react';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { App } from './App';
 import { useCityStore } from '../state/store';
 import { World } from '../core/world';
 
 describe('App', () => {
   beforeEach(() => {
-    useCityStore.setState((s) => ({ ...s, world: new World() }));
+    useCityStore.setState((s) => ({
+      ...s,
+      world: new World(),
+      buildMode: 'Road',
+      history: [],
+      future: []
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('places a road when a cell is clicked', () => {
@@ -18,5 +28,25 @@ describe('App', () => {
     expect(world.getBuilding(0, 0)?.type).toBe('Road');
     const updatedCell = getByTestId('cell-0-0');
     expect(updatedCell.getAttribute('fill')).toBe('#666');
+  });
+
+  it('allows selecting building type and placing it', () => {
+    const { getByTestId } = render(<App />);
+    fireEvent.click(getByTestId('tool-residential'));
+    const cell = getByTestId('cell-1-1');
+    fireEvent.click(cell);
+    const world = useCityStore.getState().world;
+    expect(world.getBuilding(1, 1)?.type).toBe('Residential');
+  });
+
+  it('supports undo and redo of placements', () => {
+    const { getByTestId } = render(<App />);
+    const cell = getByTestId('cell-2-2');
+    fireEvent.click(cell);
+    expect(useCityStore.getState().world.getBuilding(2, 2)?.type).toBe('Road');
+    fireEvent.click(getByTestId('undo-btn'));
+    expect(useCityStore.getState().world.getBuilding(2, 2)).toBeUndefined();
+    fireEvent.click(getByTestId('redo-btn'));
+    expect(useCityStore.getState().world.getBuilding(2, 2)?.type).toBe('Road');
   });
 });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,7 +5,7 @@ const GRID_SIZE = 20;
 const CELL_SIZE = 20;
 
 export const App: React.FC = () => {
-  const { state, world, placeRoad } = useCityStore();
+  const { state, world, buildMode, setBuildMode, placeBuilding, undo, redo } = useCityStore();
   const lines: JSX.Element[] = [];
   for (let i = 0; i <= GRID_SIZE; i++) {
     lines.push(
@@ -19,7 +19,23 @@ export const App: React.FC = () => {
   for (let y = 0; y < GRID_SIZE; y++) {
     for (let x = 0; x < GRID_SIZE; x++) {
       const building = world.getBuilding(x, y);
-      const fill = building?.type === 'Road' ? '#666' : 'transparent';
+      let fill = 'transparent';
+      if (building) {
+        switch (building.type) {
+          case 'Road':
+            fill = '#666';
+            break;
+          case 'Residential':
+            fill = '#4caf50';
+            break;
+          case 'Industrial':
+            fill = '#ffeb3b';
+            break;
+          case 'PowerPlant':
+            fill = '#f44336';
+            break;
+        }
+      }
       cells.push(
         <rect
           key={`${x}-${y}`}
@@ -30,7 +46,7 @@ export const App: React.FC = () => {
           height={CELL_SIZE}
           fill={fill}
           stroke="none"
-          onClick={() => placeRoad(x, y)}
+          onClick={() => placeBuilding(x, y)}
         />
       );
     }
@@ -38,6 +54,38 @@ export const App: React.FC = () => {
   return (
     <div className="app">
       <h1>Sim City MVP</h1>
+      <div className="toolbar">
+        <button data-testid="tool-road" onClick={() => setBuildMode('Road')} disabled={buildMode === 'Road'}>
+          Road
+        </button>
+        <button
+          data-testid="tool-residential"
+          onClick={() => setBuildMode('Residential')}
+          disabled={buildMode === 'Residential'}
+        >
+          Residential
+        </button>
+        <button
+          data-testid="tool-industrial"
+          onClick={() => setBuildMode('Industrial')}
+          disabled={buildMode === 'Industrial'}
+        >
+          Industrial
+        </button>
+        <button
+          data-testid="tool-power"
+          onClick={() => setBuildMode('PowerPlant')}
+          disabled={buildMode === 'PowerPlant'}
+        >
+          PowerPlant
+        </button>
+        <button data-testid="undo-btn" onClick={undo}>
+          Undo
+        </button>
+        <button data-testid="redo-btn" onClick={redo}>
+          Redo
+        </button>
+      </div>
       <div>Day: {state.day}</div>
       <div>Balance: {state.balance}</div>
       <div>Population: {state.population}</div>

--- a/src/core/world.ts
+++ b/src/core/world.ts
@@ -24,6 +24,10 @@ export class World {
     this.buildings.set(this.coord(x, y), building);
   }
 
+  removeBuilding(x: number, y: number) {
+    this.buildings.delete(this.coord(x, y));
+  }
+
   getBuilding(x: number, y: number): Building | undefined {
     return this.buildings.get(this.coord(x, y));
   }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,13 +1,65 @@
 import create from 'zustand';
-import { CityState, BuildingBase } from '../core/types';
+import { CityState, BuildingBase, Building } from '../core/types';
 import { World } from '../core/world';
+
+interface HistoryEntry {
+  x: number;
+  y: number;
+  prev?: Building;
+  next?: Building;
+}
 
 interface CityStore {
   state: CityState;
   world: World;
+  buildMode: BuildingBase['type'];
+  history: HistoryEntry[];
+  future: HistoryEntry[];
   setState: (partial: Partial<CityState>) => void;
-  placeRoad: (x: number, y: number) => void;
+  setBuildMode: (mode: BuildingBase['type']) => void;
+  placeBuilding: (x: number, y: number) => void;
+  undo: () => void;
+  redo: () => void;
 }
+
+const createBuilding = (type: BuildingBase['type'], x: number, y: number): Building => {
+  switch (type) {
+    case 'Residential':
+      return {
+        id: `res-${x}-${y}`,
+        type: 'Residential',
+        buildCost: 0,
+        upkeepPerDay: 0,
+        energyUseKW: 5,
+        capacity: 10
+      };
+    case 'Industrial':
+      return {
+        id: `ind-${x}-${y}`,
+        type: 'Industrial',
+        buildCost: 0,
+        upkeepPerDay: 0,
+        energyUseKW: 8,
+        jobs: 7,
+        productivity: 1
+      };
+    case 'PowerPlant':
+      return {
+        id: `pow-${x}-${y}`,
+        type: 'PowerPlant',
+        buildCost: 0,
+        upkeepPerDay: 0,
+        capacityMW: 1
+      };
+    default:
+      return {
+        id: `road-${x}-${y}`,
+        type: 'Road',
+        buildCost: 0,
+        upkeepPerDay: 0
+      };
+  }
+};
 
 export const useCityStore = create<CityStore>((set) => ({
   state: {
@@ -19,16 +71,44 @@ export const useCityStore = create<CityStore>((set) => ({
     loans: null
   },
   world: new World(),
+  buildMode: 'Road',
+  history: [],
+  future: [],
   setState: (partial) => set((s) => ({ state: { ...s.state, ...partial } })),
-  placeRoad: (x, y) =>
+  setBuildMode: (mode) => set({ buildMode: mode }),
+  placeBuilding: (x, y) =>
     set((s) => {
-      const road: BuildingBase = {
-        id: `road-${x}-${y}`,
-        type: 'Road',
-        buildCost: 0,
-        upkeepPerDay: 0
+      const prev = s.world.getBuilding(x, y);
+      const next = createBuilding(s.buildMode, x, y);
+      s.world.placeBuilding(x, y, next);
+      return {
+        world: s.world,
+        history: [...s.history, { x, y, prev, next }],
+        future: []
       };
-      s.world.placeBuilding(x, y, road);
-      return { world: s.world };
+    }),
+  undo: () =>
+    set((s) => {
+      const history = [...s.history];
+      const last = history.pop();
+      if (!last) return {};
+      if (last.prev) {
+        s.world.placeBuilding(last.x, last.y, last.prev);
+      } else {
+        s.world.removeBuilding(last.x, last.y);
+      }
+      return { world: s.world, history, future: [...s.future, last] };
+    }),
+  redo: () =>
+    set((s) => {
+      const future = [...s.future];
+      const next = future.pop();
+      if (!next) return {};
+      if (next.next) {
+        s.world.placeBuilding(next.x, next.y, next.next);
+      } else {
+        s.world.removeBuilding(next.x, next.y);
+      }
+      return { world: s.world, history: [...s.history, next], future };
     })
 }));


### PR DESCRIPTION
## Summary
- Implement toolbar to choose building types and provide undo/redo controls
- Track build mode and placement history in store
- Add tests covering building selection and undo/redo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964126527083288a189f27e8f5f30f